### PR TITLE
Add repositories to resolve snapshot versions and rename Metals preferences

### DIFF
--- a/lsp-scala-plugin/plugin.xml
+++ b/lsp-scala-plugin/plugin.xml
@@ -118,7 +118,7 @@
       <page
             class="com.idiomaticsoft.lsp.scala.preferences.MetalsPreference"
             id="lsp-scala-plugin.page1"
-            name="Metals preferences">
+            name="Metals">
       </page>
    </extension>
 </plugin>

--- a/lsp-scala-plugin/src/main/scala/com/idiomaticsoft/lsp/scala/metals/MetalsLaunchConfigurationDelegate.scala
+++ b/lsp-scala-plugin/src/main/scala/com/idiomaticsoft/lsp/scala/metals/MetalsLaunchConfigurationDelegate.scala
@@ -1,14 +1,14 @@
-/*******************************************************************************
- * Copyright (c) 2019 Idiomaticsoft S.R.L. and others.
- * This program and the accompanying materials are made
- * available under the terms of the APACHE LICENSE, VERSION 2.0
- * which is available at https://www.apache.org/licenses/LICENSE-2.0.txt
- *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Contributors:
- *  Edmundo Lopez B. (Idiomaticsoft S.R.L.) - initial implementation
- *******************************************************************************/
+/** *****************************************************************************
+  * Copyright (c) 2019 Idiomaticsoft S.R.L. and others.
+  * This program and the accompanying materials are made
+  * available under the terms of the APACHE LICENSE, VERSION 2.0
+  * which is available at https://www.apache.org/licenses/LICENSE-2.0.txt
+  *
+  * SPDX-License-Identifier: Apache-2.0
+  *
+  * Contributors:
+  * Edmundo Lopez B. (Idiomaticsoft S.R.L.) - initial implementation
+  * ******************************************************************************/
 
 package com.idiomaticsoft.lsp.scala.metals
 
@@ -49,10 +49,16 @@ class MetalsLaunchConfigurationDelegate extends JavaLaunchDelegate {
       import coursier._
       val fetch = Fetch()
         .addDependencies(
-			Dependency(
-			 mod"org.scalameta:metals_2.12",
-			 metalsVersion
-			)).run()
+          Dependency(
+            mod"org.scalameta:metals_2.12",
+            metalsVersion
+          )
+        )
+        .addRepositories(
+          Repositories.sonatype("public"),
+          Repositories.sonatype("snapshots"),
+          Repositories.bintray("scalacenter", "releases")
+        ).run()
       import collection.JavaConverters._
       val classPathElements = fetch
         .map(x => new Path(x.toPath.toString()))


### PR DESCRIPTION
When added snapshot versions from the Metals website Eclipse just froze and broke totally. Added repositories to make sure it will work at least with supported snapshots.

Also renamed the preferences section, since it seems to be the way other preferences are declared and `preferences` word is redundant.

@mundacho Let me know what you think!